### PR TITLE
Massage OpenAPI Spec for Code Generation

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -856,4 +856,10 @@ components:
         'Set to "relink-account" to start Ignition session to re-authenticate
         user. Must also provide `account`. '
   responses: {}
-  securitySchemes: {}
+  securitySchemes: 
+   apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X_API_KEY
+      description: API key based authentication
+              


### PR DESCRIPTION
In order to generate code using fern, the OpenAPI spec must pass fern check. Here's a summary of the changes we made to get to green:
- Updated securityScheme (currently something temporary. Needs to be updated again)